### PR TITLE
Infra: fix package dependencies for workflows

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -13,11 +13,31 @@ on:
         value: ${{ jobs.build.outputs.build-cache-key }}
 
 jobs:
+  # TODO: Extract these checks together with the restore build output part below into a separate custom action
+  check-fileio:
+    name: Check if fileio version exists in npm registry
+    if: inputs.package-name == 'shell'
+    uses: ./.github/workflows/_check-if-npm-version-exists.yml
+    with:
+      package-name: fileio
+
+  check-ui:
+    name: Check if ui version exists in npm registry
+    if: inputs.package-name == 'shell'
+    uses: ./.github/workflows/_check-if-npm-version-exists.yml
+    with:
+      package-name: ui
+
   build:
     runs-on: ubuntu-latest
 
     outputs:
       build-cache-key: ${{ steps.cache-build-output.outputs.cache-hit }}
+
+    needs:
+      - check-fileio
+      - check-ui
+    if: always()
 
     steps:
       - name: Checkout
@@ -41,6 +61,45 @@ jobs:
         run: |
           VERSION=$(grep version package.json | sed 's/.*"version": "\(.*\)".*/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      # TODO: Extract the restore build output part into a separate custom action
+      - name: Extract fileio version
+        id: fileio-version
+        working-directory: packages/fileio
+        if: inputs.package-name == 'shell' && needs.check-fileio.outputs.npm_version_exists == 'false'
+        run: |
+          VERSION=$(grep version package.json | sed 's/.*"version": "\(.*\)".*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Restore fileio build output cache
+        uses: actions/cache@v3
+        if: inputs.package-name == 'shell' && needs.check-fileio.outputs.npm_version_exists == 'false'
+        with:
+          path: 'packages/fileio/dist'
+          key: ${{ runner.os }}-build-output-fileio-${{ hashFiles( '**/packages/fileio/pnpm-lock.yaml', '**/packages/fileio/src/**', '**/packages/fileio/package.json' ) }}-${{ steps.fileio-version.outputs.version }}
+
+      - name: Verify fileio build output exists
+        if: inputs.package-name == 'shell' && needs.check-fileio.outputs.npm_version_exists == 'false'
+        run: ls -la 'packages/fileio/dist'
+
+      - name: Extract ui version
+        id: ui-version
+        working-directory: packages/ui
+        if: inputs.package-name == 'shell' && needs.check-ui.outputs.npm_version_exists == 'false'
+        run: |
+          VERSION=$(grep version package.json | sed 's/.*"version": "\(.*\)".*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Restore ui build output cache
+        uses: actions/cache@v3
+        if: inputs.package-name == 'shell' && needs.check-ui.outputs.npm_version_exists == 'false'
+        with:
+          path: 'packages/ui/dist'
+          key: ${{ runner.os }}-build-output-ui-${{ hashFiles( '**/packages/ui/pnpm-lock.yaml', '**/packages/ui/src/**', '**/packages/ui/package.json' ) }}-${{ steps.ui-version.outputs.version }}
+
+      - name: Verify ui build output exists
+        if: inputs.package-name == 'shell' && needs.check-ui.outputs.npm_version_exists == 'false'
+        run: ls -la 'packages/ui/dist'
 
       - name: Setup build output cache
         id: cache-build-output

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -16,14 +16,14 @@ jobs:
   # TODO: Extract these checks together with the restore build output part below into a separate custom action
   check-fileio:
     name: Check if fileio version exists in npm registry
-    if: inputs.package-name == 'shell'
+    if: inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure'
     uses: ./.github/workflows/_check-if-npm-version-exists.yml
     with:
       package-name: fileio
 
   check-ui:
     name: Check if ui version exists in npm registry
-    if: inputs.package-name == 'shell'
+    if: inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure'
     uses: ./.github/workflows/_check-if-npm-version-exists.yml
     with:
       package-name: ui
@@ -66,39 +66,39 @@ jobs:
       - name: Extract fileio version
         id: fileio-version
         working-directory: packages/fileio
-        if: inputs.package-name == 'shell' && needs.check-fileio.outputs.npm_version_exists == 'false'
+        if: (inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure') && needs.check-fileio.outputs.npm_version_exists == 'false'
         run: |
           VERSION=$(grep version package.json | sed 's/.*"version": "\(.*\)".*/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Restore fileio build output cache
         uses: actions/cache@v3
-        if: inputs.package-name == 'shell' && needs.check-fileio.outputs.npm_version_exists == 'false'
+        if: (inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure') && needs.check-fileio.outputs.npm_version_exists == 'false'
         with:
           path: 'packages/fileio/dist'
           key: ${{ runner.os }}-build-output-fileio-${{ hashFiles( '**/packages/fileio/pnpm-lock.yaml', '**/packages/fileio/src/**', '**/packages/fileio/package.json' ) }}-${{ steps.fileio-version.outputs.version }}
 
       - name: Verify fileio build output exists
-        if: inputs.package-name == 'shell' && needs.check-fileio.outputs.npm_version_exists == 'false'
+        if: (inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure') && needs.check-fileio.outputs.npm_version_exists == 'false'
         run: ls -la 'packages/fileio/dist'
 
       - name: Extract ui version
         id: ui-version
         working-directory: packages/ui
-        if: inputs.package-name == 'shell' && needs.check-ui.outputs.npm_version_exists == 'false'
+        if: (inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure') && needs.check-ui.outputs.npm_version_exists == 'false'
         run: |
           VERSION=$(grep version package.json | sed 's/.*"version": "\(.*\)".*/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Restore ui build output cache
         uses: actions/cache@v3
-        if: inputs.package-name == 'shell' && needs.check-ui.outputs.npm_version_exists == 'false'
+        if: (inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure') && needs.check-ui.outputs.npm_version_exists == 'false'
         with:
           path: 'packages/ui/dist'
           key: ${{ runner.os }}-build-output-ui-${{ hashFiles( '**/packages/ui/pnpm-lock.yaml', '**/packages/ui/src/**', '**/packages/ui/package.json' ) }}-${{ steps.ui-version.outputs.version }}
 
       - name: Verify ui build output exists
-        if: inputs.package-name == 'shell' && needs.check-ui.outputs.npm_version_exists == 'false'
+        if: (inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure') && needs.check-ui.outputs.npm_version_exists == 'false'
         run: ls -la 'packages/ui/dist'
 
       - name: Setup build output cache

--- a/.github/workflows/_check-if-npm-version-exists.yml
+++ b/.github/workflows/_check-if-npm-version-exists.yml
@@ -19,7 +19,7 @@ jobs:
       npm_version_exists: ${{ steps.check_npm_version.outputs.npm_version_exists }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check if version exists in npm registry
         id: check_npm_version

--- a/.github/workflows/_check-npm-version.yml
+++ b/.github/workflows/_check-npm-version.yml
@@ -22,7 +22,7 @@ jobs:
       version_changed: ${{ steps.compare_versions.outputs.version_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Extract Current Version
         id: current_version

--- a/.github/workflows/_check-version.yml
+++ b/.github/workflows/_check-version.yml
@@ -24,7 +24,7 @@ jobs:
       version_changed: ${{ steps.final_output.outputs.version_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Verify Branch
         id: verify_branch
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Checkout Main Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: steps.verify_branch.outputs.deployment_branch_exists == 'true'
         with:
           ref: 'main'
@@ -53,7 +53,7 @@ jobs:
           echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout Deployed App
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: steps.verify_branch.outputs.deployment_branch_exists == 'true'
         with:
           repository: 'SeptKit/septkit.github.io'

--- a/.github/workflows/_extract-version.yml
+++ b/.github/workflows/_extract-version.yml
@@ -19,7 +19,7 @@ jobs:
       version: ${{ steps.extract-version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Extract Version
         id: extract-version

--- a/.github/workflows/_install-shell.yml
+++ b/.github/workflows/_install-shell.yml
@@ -57,12 +57,16 @@ jobs:
 
   cache-and-install-shell:
     runs-on: ubuntu-latest
+
     needs:
       - check-fileio
       - build-fileio
       - check-ui
       - build-ui
     if: always()
+
+    permissions:
+      contents: write
 
     outputs:
       cache-key: ${{ steps.cache-node-modules.outputs.cache-hit }}
@@ -84,6 +88,14 @@ jobs:
           path: packages/shell/node_modules
           key: ${{ runner.os }}-node-modules-shell-${{ hashFiles( '**/packages/shell/pnpm-lock.yaml' ) }}
 
+      # hacky way to enforce fetching from npm registry if fileio version exists in npm registry
+      - name: Delete fileio folder
+        if: needs.check-fileio.outputs.npm_version_exists == 'true'
+        run: |
+          echo "Fileio version exists in npm registry"
+          echo "Deleting fileio folder to enforce fetching from npm registry"
+          rm -rf packages/fileio
+
       # TODO: Extract the restore build output part into a separate custom action
       - name: Extract fileio version
         id: fileio-version
@@ -104,6 +116,14 @@ jobs:
         if: needs.check-fileio.outputs.npm_version_exists == 'false'
         run: ls -la 'packages/fileio/dist'
 
+      # hacky way to enforce fetching from npm registry if ui version exists in npm registry
+      - name: Delete ui folder
+        if: needs.check-ui.outputs.npm_version_exists == 'true'
+        run: |
+          echo "ui version exists in npm registry"
+          echo "Deleting ui folder to enforce fetching from npm registry"
+          rm -rf packages/ui
+
       - name: Extract ui version
         id: ui-version
         working-directory: packages/ui
@@ -122,6 +142,17 @@ jobs:
       - name: Verify ui build output exists
         if: needs.check-ui.outputs.npm_version_exists == 'false'
         run: ls -la 'packages/ui/dist'
+
+      - name: Delete pnpm lock file # File was causing issues with workspace links and prevented fetching packages from npm registry
+        working-directory: packages/shell
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' || needs.check-fileio.outputs.npm_version_exists == 'false' || needs.check-ui.outputs.npm_version_exists == 'false'
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            echo "Deleting pnpm-lock.yaml to enforce fetching from npm registry"
+            rm pnpm-lock.yaml
+          else
+            echo "pnpm-lock.yaml does not exist, skipping deletion"
+          fi
 
       - name: Install dependencies
         run: pnpm install --filter=./packages/shell --ignore-scripts

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -12,14 +12,14 @@ jobs:
   # TODO: Extract these checks together with the restore build output part below into a separate custom action
   check-fileio:
     name: Check if fileio version exists in npm registry
-    if: inputs.package-name == 'shell'
+    if: inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure'
     uses: ./.github/workflows/_check-if-npm-version-exists.yml
     with:
       package-name: fileio
 
   check-ui:
     name: Check if ui version exists in npm registry
-    if: inputs.package-name == 'shell'
+    if: inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure'
     uses: ./.github/workflows/_check-if-npm-version-exists.yml
     with:
       package-name: ui
@@ -63,39 +63,39 @@ jobs:
       - name: Extract fileio version
         id: fileio-version
         working-directory: packages/fileio
-        if: inputs.package-name == 'shell' && needs.check-fileio.outputs.npm_version_exists == 'false'
+        if: (inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure') && needs.check-fileio.outputs.npm_version_exists == 'false'
         run: |
           VERSION=$(grep version package.json | sed 's/.*"version": "\(.*\)".*/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Restore fileio build output cache
         uses: actions/cache@v3
-        if: inputs.package-name == 'shell' && needs.check-fileio.outputs.npm_version_exists == 'false'
+        if: (inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure') && needs.check-fileio.outputs.npm_version_exists == 'false'
         with:
           path: 'packages/fileio/dist'
           key: ${{ runner.os }}-build-output-fileio-${{ hashFiles( '**/packages/fileio/pnpm-lock.yaml', '**/packages/fileio/src/**', '**/packages/fileio/package.json' ) }}-${{ steps.fileio-version.outputs.version }}
 
       - name: Verify fileio build output exists
-        if: inputs.package-name == 'shell' && needs.check-fileio.outputs.npm_version_exists == 'false'
+        if: (inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure') && needs.check-fileio.outputs.npm_version_exists == 'false'
         run: ls -la 'packages/fileio/dist'
 
       - name: Extract ui version
         id: ui-version
         working-directory: packages/ui
-        if: inputs.package-name == 'shell' && needs.check-ui.outputs.npm_version_exists == 'false'
+        if: (inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure') && needs.check-ui.outputs.npm_version_exists == 'false'
         run: |
           VERSION=$(grep version package.json | sed 's/.*"version": "\(.*\)".*/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Restore ui build output cache
         uses: actions/cache@v3
-        if: inputs.package-name == 'shell' && needs.check-ui.outputs.npm_version_exists == 'false'
+        if: (inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure') && needs.check-ui.outputs.npm_version_exists == 'false'
         with:
           path: 'packages/ui/dist'
           key: ${{ runner.os }}-build-output-ui-${{ hashFiles( '**/packages/ui/pnpm-lock.yaml', '**/packages/ui/src/**', '**/packages/ui/package.json' ) }}-${{ steps.ui-version.outputs.version }}
 
       - name: Verify ui build output exists
-        if: inputs.package-name == 'shell' && needs.check-ui.outputs.npm_version_exists == 'false'
+        if: (inputs.package-name == 'shell' || inputs.package-name == 'extensions/structure') && needs.check-ui.outputs.npm_version_exists == 'false'
         run: ls -la 'packages/ui/dist'
 
       - name: Run Tests

--- a/.github/workflows/deploy-ext-structure.yml
+++ b/.github/workflows/deploy-ext-structure.yml
@@ -11,10 +11,7 @@ on:
 jobs:
   install:
     name: Install Dependencies
-    uses: ./.github/workflows/_install.yml
-    with:
-      package-name: extensions/structure
-
+    uses: ./.github/workflows/_install-ext-structure.yml
   build:
     name: Build Project
     needs: install

--- a/.github/workflows/install-ext-structure.yml
+++ b/.github/workflows/install-ext-structure.yml
@@ -1,0 +1,176 @@
+name: _install
+on:
+  workflow_call:
+    outputs:
+      cache-key:
+        description: 'Cache key for extensions/structure node_modules'
+        value: ${{ jobs.cache-and-install-extensions/structure.outputs.cache-key }}
+
+jobs:
+  check-fileio:
+    name: Check if fileio version exists in npm registry
+    uses: ./.github/workflows/_check-if-npm-version-exists.yml
+    with:
+      package-name: fileio
+
+  install-fileio-dependencies:
+    name: Install fileio dependencies
+    needs: check-fileio
+    if: needs.check-fileio.outputs.npm_version_exists == 'false'
+    uses: ./.github/workflows/_install.yml
+    with:
+      package-name: fileio
+
+  build-fileio:
+    name: Build fileio
+    needs:
+      - check-fileio
+      - install-fileio-dependencies
+    if: needs.check-fileio.outputs.npm_version_exists == 'false'
+    uses: ./.github/workflows/_build.yml
+    with:
+      package-name: fileio
+
+  check-ui:
+    name: Check if ui version exists in npm registry
+    uses: ./.github/workflows/_check-if-npm-version-exists.yml
+    with:
+      package-name: ui
+
+  install-ui-dependencies:
+    name: Install ui dependencies
+    needs: check-ui
+    if: needs.check-ui.outputs.npm_version_exists == 'false'
+    uses: ./.github/workflows/_install.yml
+    with:
+      package-name: ui
+
+  build-ui:
+    name: Build ui
+    needs:
+      - check-ui
+      - install-ui-dependencies
+    if: needs.check-ui.outputs.npm_version_exists == 'false'
+    uses: ./.github/workflows/_build.yml
+    with:
+      package-name: ui
+
+  cache-and-install-ext-structure:
+    runs-on: ubuntu-latest
+
+    needs:
+      - check-fileio
+      - build-fileio
+      - check-ui
+      - build-ui
+    if: always()
+
+    permissions:
+      contents: write
+
+    outputs:
+      cache-key: ${{ steps.cache-node-modules.outputs.cache-hit }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 10.10.0
+          run_install: false
+
+      - name: Setup node_modules Cache
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: packages/extensions/structure/node_modules
+          key: ${{ runner.os }}-node-modules-extensions/structure-${{ hashFiles( '**/packages/extensions/structure/pnpm-lock.yaml' ) }}
+
+      # hacky way to enforce fetching from npm registry if fileio version exists in npm registry
+      - name: Delete fileio folder
+        if: needs.check-fileio.outputs.npm_version_exists == 'true'
+        run: |
+          echo "Fileio version exists in npm registry"
+          echo "Deleting fileio folder to enforce fetching from npm registry"
+          rm -rf packages/fileio
+
+      # TODO: Extract the restore build output part into a separate custom action
+      - name: Extract fileio version
+        id: fileio-version
+        working-directory: packages/fileio
+        if: needs.check-fileio.outputs.npm_version_exists == 'false'
+        run: |
+          VERSION=$(grep version package.json | sed 's/.*"version": "\(.*\)".*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Restore fileio build output cache
+        uses: actions/cache@v3
+        if: needs.check-fileio.outputs.npm_version_exists == 'false'
+        with:
+          path: 'packages/fileio/dist'
+          key: ${{ runner.os }}-build-output-fileio-${{ hashFiles( '**/packages/fileio/pnpm-lock.yaml', '**/packages/fileio/src/**', '**/packages/fileio/package.json' ) }}-${{ steps.fileio-version.outputs.version }}
+
+      - name: Verify fileio build output exists
+        if: needs.check-fileio.outputs.npm_version_exists == 'false'
+        run: ls -la 'packages/fileio/dist'
+
+      # hacky way to enforce fetching from npm registry if ui version exists in npm registry
+      - name: Delete ui folder
+        if: needs.check-ui.outputs.npm_version_exists == 'true'
+        run: |
+          echo "ui version exists in npm registry"
+          echo "Deleting ui folder to enforce fetching from npm registry"
+          rm -rf packages/ui
+
+      - name: Extract ui version
+        id: ui-version
+        working-directory: packages/ui
+        if: needs.check-ui.outputs.npm_version_exists == 'false'
+        run: |
+          VERSION=$(grep version package.json | sed 's/.*"version": "\(.*\)".*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Restore ui build output cache
+        uses: actions/cache@v3
+        if: needs.check-ui.outputs.npm_version_exists == 'false'
+        with:
+          path: 'packages/ui/dist'
+          key: ${{ runner.os }}-build-output-ui-${{ hashFiles( '**/packages/ui/pnpm-lock.yaml', '**/packages/ui/src/**', '**/packages/ui/package.json' ) }}-${{ steps.ui-version.outputs.version }}
+
+      - name: Verify ui build output exists
+        if: needs.check-ui.outputs.npm_version_exists == 'false'
+        run: ls -la 'packages/ui/dist'
+
+      - name: Delete pnpm lock file # Temporary solution as file was causing issues with workspace links and prevented fetching packages from npm registry
+        working-directory: packages/extensions/structure
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' || needs.check-fileio.outputs.npm_version_exists == 'false' || needs.check-ui.outputs.npm_version_exists == 'false'
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            echo "Deleting pnpm-lock.yaml to enforce fetching from npm registry"
+            rm pnpm-lock.yaml
+          else
+            echo "pnpm-lock.yaml does not exist, skipping deletion"
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --filter=./packages/extensions/structure --ignore-scripts
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' || needs.check-fileio.outputs.npm_version_exists == 'false' || needs.check-ui.outputs.npm_version_exists == 'false'
+
+      - name: Get Playwright Version
+        id: playwright-version
+        working-directory: packages/extensions/structure
+        run: echo "playwright_version=$(node -e "console.log(require('./package.json').devDependencies['playwright'])")" >>  $GITHUB_OUTPUT
+
+      - name: Setup Playwright Cache
+        uses: actions/cache@v3
+        id: cache-playwright
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.playwright_version }}
+
+      - name: Install Playwright
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        working-directory: packages/extensions/structure
+        run: npx playwright install chromium --with-deps

--- a/.github/workflows/install-ext-structure.yml
+++ b/.github/workflows/install-ext-structure.yml
@@ -4,7 +4,7 @@ on:
     outputs:
       cache-key:
         description: 'Cache key for extensions/structure node_modules'
-        value: ${{ jobs.cache-and-install-extensions/structure.outputs.cache-key }}
+        value: ${{ jobs.cache-and-install-ext-structure.outputs.cache-key }}
 
 jobs:
   check-fileio:

--- a/.github/workflows/quality-check-ext-structure.yml
+++ b/.github/workflows/quality-check-ext-structure.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   install:
     name: Install Dependencies
-    uses: ./.github/workflows/_install.yml
+    uses: ./.github/workflows/_install-ext-structure.yml
     with:
       package-name: extensions/structure
 

--- a/packages/extensions/structure/src/app.vue
+++ b/packages/extensions/structure/src/app.vue
@@ -7,7 +7,7 @@
 			}"
 		>
 			<h1 class="text-5xl font-bold text-center my-8 uppercase tracking-wider">Structure</h1>
-			<h2 class="text-2xl text-center font-semibold my-4">Template for SET Extensions</h2>
+			<h2 class="text-2xl text-center font-semibold my-4">Template for SET Extensions Test</h2>
 			<h2 class="text-2xl text-center font-semibold my-4">file: {{ fileName }}</h2>
 		</div>
 	</Layout>

--- a/packages/extensions/structure/src/app.vue
+++ b/packages/extensions/structure/src/app.vue
@@ -7,7 +7,7 @@
 			}"
 		>
 			<h1 class="text-5xl font-bold text-center my-8 uppercase tracking-wider">Structure</h1>
-			<h2 class="text-2xl text-center font-semibold my-4">Template for SET Extensions Test</h2>
+			<h2 class="text-2xl text-center font-semibold my-4">Template for SET Extensions</h2>
 			<h2 class="text-2xl text-center font-semibold my-4">file: {{ fileName }}</h2>
 		</div>
 	</Layout>

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@septkit/shell",
-	"version": "1",
+	"version": "2",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Workaround solution for now:
- Delete ui and fileio folders for shell and structure extension before installing its dependencies to enforce fetching packages from npm registry if available
- Delete pnpm-lock.yaml file for shell and structure extension before installing its dependencies which was for some reason causing issues with the first bullet point