### PR TITLE
Bug: Open twice the same file

### DIFF
--- a/packages/fileio/package.json
+++ b/packages/fileio/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@septkit/fileio",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"description": "",
 	"main": "index.js",
 	"type": "module",

--- a/packages/fileio/src/import/import.database.ts
+++ b/packages/fileio/src/import/import.database.ts
@@ -109,3 +109,28 @@ export async function bulkCreateTables(params: {
 	databaseInstance.version(databaseInstanceCurrentVersion + 1).stores(newSchema)
 	databaseInstance.open()
 }
+
+/**
+ * Deletes a Dexie/IndexedDB database if it exists.
+ * Closes before deleting if open.
+ * @param dbName Name of the database to delete
+ * @returns if DB was deleted
+ */
+export async function deleteDatabaseIfExists(dbName: string): Promise<boolean> {
+	// Check existence
+	const dbs = (await indexedDB.databases?.()) || []
+	const found = dbs.some((db) => db.name === dbName)
+	if (!found) return false // DB does not exist
+
+	// Close any open instance
+	try {
+		const db = new Dexie(dbName)
+		await db.close()
+	} catch (e) {
+		console.warn(`Failed to close database ${dbName} before deletion`, e)
+	}
+
+	// Delete DB
+	await Dexie.delete(dbName)
+	return true
+}

--- a/packages/fileio/src/import/import.main.ts
+++ b/packages/fileio/src/import/import.main.ts
@@ -2,7 +2,7 @@ import * as sax from 'sax'
 // XML PARSER
 import { setSaxParser } from './import.parser'
 // DATABASE
-import { initializeDatabaseInstance } from './import.database'
+import { deleteDatabaseIfExists, initializeDatabaseInstance } from './import.database'
 // CONSTANTS
 import { SUPPORTED_EXTENSIONS } from '../common/common.constant'
 // QUEUE
@@ -38,8 +38,9 @@ export async function importXmlFiles({
 		}
 
 		const databaseName = await importFile({ file, options })
-
-		databaseNames.push(databaseName)
+		if (databaseName) {
+			databaseNames.push(databaseName)
+		}
 	}
 
 	return databaseNames
@@ -61,6 +62,7 @@ async function importFile(params: { file: File; options: ImportOptions }) {
 
 	try {
 		const databaseName = getDatabaseName(file)
+		await deleteDatabaseIfExists(databaseName)
 
 		const databaseInstance = initializeDatabaseInstance(databaseName)
 


### PR DESCRIPTION
> Steps to reproduce:
> 
> Open a file
> Open a file with the same name again
> Current:
> 
> It just writes the whole file content again into the existing database
> Expexted:
> 
> Check for diffs/updates or replacing the already existing data
> Hints:
> 
> E.g. I open an SSD with 5 LNodes, I have 5 LNodes in the DB. Then I open the same SSD again, I have now 10 LNodes in the DB and also when exporting/saving the XML.

[https://github.com/SeptKit/set/issues/183](url)

E.g. test file ref 9 should just have 10 LNodes, and no duplicates:
<img width="1766" height="1558" alt="image" src="https://github.com/user-attachments/assets/dbbd7541-570d-4050-86d2-fb2c27805544" />
